### PR TITLE
Added width, height configuration variables

### DIFF
--- a/MMM-YouTube.js
+++ b/MMM-YouTube.js
@@ -9,6 +9,8 @@ Module.register("MMM-YouTube", {
       cc_load_policy: 0,
     },
     defaultQuality: "default",
+    width: "800px",
+    height: "600px",
     volume: 100,
     disableCC: true,
     showPlayingOnly: true,
@@ -96,6 +98,8 @@ Module.register("MMM-YouTube", {
     var dom = document.createElement("div")
     dom.id = "YOUTUBE"
     if (this.config.showPlayingOnly) dom.style.display = "none"
+    dom.style.width = this.config.width
+    dom.style.height = this.config.height
     var player = document.createElement("div")
     player.id = "YOUTUBE_PLAYER"
     dom.appendChild(player)
@@ -286,9 +290,15 @@ Module.register("MMM-YouTube", {
       kind: kind,
       code: ev.data
     })
-    if (ev.data == 2) {
-      ev.target.stopVideo()
+// Avoid race condition - stop an already stopped video loops this function indefinitely
+//    if (ev.data == 2) {
+//      ev.target.stopVideo()
+//    }
+// Work around, 150 unavailable, try to load next video in playlist to keep going
+    if (ev.data == 150) {
+      ev.target.nextVideo()
     }
+
   },
 
   makeYTOptions: function(options={}) {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ MagicMirror module for youtube player with runtime configuration and controllabl
 - Controllable by MMM-TelegramBot command
 
 ## New Update
+**[1.0.4]**
+- Added width and height to config options to set Youtube window in MM - 13/03/2020 andyb2000
+
 **[1.0.3]**
 - added: `YOUTUBE_PLAYER_ERROR` (payload:{kind, code}) notification will be emitted on youtube player error.
 
@@ -43,6 +46,8 @@ You don't need to copy & paste all of these. Just select what you need and rewri
   config: {
     verbose:true,
     defaultQuality: "default",
+    width: "800px",
+    height: "600px",
     volume: 100,
     disableCC: true,
     showPlayingOnly: true,


### PR DESCRIPTION
Hi,
I've made a couple of amends:
* width+height of Youtube window now defined in MM configuration instead of static in css
* Fixed race condition in notifications where a video generates error 2 it sent a 'stopVideo', however as video had already stopped this then caused another error and so on, causing a race condition in notifications.
* Added auto-skip to next video when a video is not permitted (error 150) to try and keep playlists running/playing.

Hope that's ok and worth merging.