### PR TITLE
change from noti to notification

### DIFF
--- a/MMM-YouTube.js
+++ b/MMM-YouTube.js
@@ -122,14 +122,14 @@ Module.register("MMM-YouTube", {
     }
   },
 
-  notificationReceived: function (noti, payload) {
-    if (noti == "DOM_OBJECTS_CREATED") {
+  notificationReceived: function (notification, payload) {
+    if (notification == "DOM_OBJECTS_CREATED") {
       this.prepare()
     }
-    if (noti == "YOUTUBE_LOAD") {
+    if (notification == "YOUTUBE_LOAD") {
       this.loadVideo(payload)
     }
-    if (noti == "YOUTUBE_CONTROL") {
+    if (notification == "YOUTUBE_CONTROL") {
       /*
         {
           command: "playVideo",


### PR DESCRIPTION
change from noti to notification so that MMM-Remote-Control can recognize it.
It enables MMM-YouTube to receive commands from MMM-Remote-Control
e.g)
curl -X POST http://magicmirrorip:8080/api/module/youtube/youtubeload \
  -H 'content-type: application/json' \
  -d '{ 
    "type": "id", 
    "id": "YouTubeVideoID"
    }'