### PR TITLE
Fix to 'resume' function

### DIFF
--- a/MMM-YouTube.js
+++ b/MMM-YouTube.js
@@ -117,7 +117,7 @@ Module.register("MMM-YouTube", {
   resume: function () {
     this.suspended = false
     var ret = this.controlPlayer("getPlayerState")
-    if (ret == 1) {
+    if (ret == 2) {
       this.controlPlayer("playVideo")
     }
   },


### PR DESCRIPTION
The 'resume' function seemed to be looking for an incorrect playerState value. It was looking for a value of 1 (playing) in order to issue playVideo. This would not work in the scenario where the player was already paused (e.g. due to a previous call to the 'suspend' function. The 'resume' function has been corrected to look for a playerState value of 2 (paused) in order to playVideo. This change ensures that playback is paused when the module is hidden and then played when the module is shown.

One other though (not implemented) would be to remove the playerState checks altogether from 'suspend' and 'resume' and simply issue pauseVideo and playVideo no matter what. I did not test this to see if there would be other problems in doing such a change.